### PR TITLE
Help functionality

### DIFF
--- a/lib/commands/help.rb
+++ b/lib/commands/help.rb
@@ -15,7 +15,7 @@ module Commands
 
       begin
         klass = Object.const_get("Commands::#{keyword.capitalize}")
-        obj = klass.new(@player)
+        obj = klass.new(@initiator)
       rescue NameError
         return command_not_found(keyword)
       end
@@ -62,9 +62,11 @@ module Commands
     def available_commands_for_initiator
       Commands.constants.map do |command|
         next if HELP_LIST_IGNORE.include? command
+
         const = Commands.const_get(command)
         next unless const.is_a? Class
         next unless const.new(@initiator).initiator_is_authorized?
+
         command.to_s.downcase
       end.compact
     end

--- a/lib/commands/help.rb
+++ b/lib/commands/help.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require_relative "command_base"
+
+module Commands
+  class Help < CommandBase
+
+    # List of Command classes to ignore
+    HELP_LIST_IGNORE = [:CommandBase, :MovementBase]
+
+    def call(args)
+      keyword = args.first
+
+      return @initiator.send_data(command_list) unless keyword
+      return @initiator.send_data(help) if keyword == "help"
+
+      begin
+        klass = Object.const_get("Commands::#{keyword.capitalize}")
+        obj = klass.new(@player)
+      rescue NameError
+        return command_not_found(keyword)
+      end
+
+      # Make sure they're able to access the command
+      return command_not_found(keyword) unless obj.initiator_is_authorized?
+      return @initiator.send_data(obj.help) if obj.respond_to?(:help)
+      @initiator.send_data("#{keyword} does not currently have a help entry.")
+    end
+
+    def command_list(column_count: 6)
+      terminal_width = `tput cols`.to_i
+      col_width = terminal_width / column_count
+
+      available_commands_for_initiator.compact
+        .sort!
+        .each_slice(column_count)
+        .to_a
+        .flat_map { |com| com.map{|c| c.ljust(col_width)} << "\n" }
+        .join
+    end
+
+    def help
+      <<~HELP
+        #{"Syntax".red}: help
+        #{"Syntax".red}: help <#{"keyword".cyan}>
+
+        "help" without any arguments shows a one-page command summary.
+
+        "help" <#{"keyword".cyan}> shows a page of help on that keyword.  The
+        keywords include all the commands, spells, and skills listed in the
+        game.
+      HELP
+    end
+
+    private
+
+    def command_not_found(command)
+      @initiator.send_data(
+        "#{command} is not a valid command. No help topic available."
+      )
+    end
+
+    def available_commands_for_initiator
+      Commands.constants.map do |command|
+        next if HELP_LIST_IGNORE.include? command
+        const = Commands.const_get(command)
+        next unless const.is_a? Class
+        next unless const.new(@initiator).initiator_is_authorized?
+        command.to_s.downcase
+      end.compact
+    end
+  end
+end

--- a/lib/commands/movement_base.rb
+++ b/lib/commands/movement_base.rb
@@ -3,6 +3,22 @@ require_relative "command_base"
 
 module Commands
   class MovementBase < CommandBase
+    def help
+      syntax = "Syntax".colorize(:red)
+      <<~HELP
+        #{"Syntax".red}: north
+        #{"Syntax".red}: northeast
+        #{"Syntax".red}: northwest
+        #{"Syntax".red}: south
+        #{"Syntax".red}: southeast
+        #{"Syntax".red}: southwest
+        #{"Syntax".red}: east
+        #{"Syntax".red}: west
+
+        Use these commands to exit the current room in a particular direction.
+      HELP
+    end
+
     private
 
     def process_move(x: 0, y: 0, exit_dir: "East", enter_dir: "West")

--- a/spec/lib/commands/east_spec.rb
+++ b/spec/lib/commands/east_spec.rb
@@ -47,6 +47,12 @@ module Commands
           end
         end
       end
+
+      describe "help" do
+        it "returns a help string" do
+          expect(subject.new(create(:player)).help).to be_a(String)
+        end
+      end
     end
   end
 end

--- a/spec/lib/commands/help_spec.rb
+++ b/spec/lib/commands/help_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Commands
+  RSpec.describe Help, type: [:command] do
+    include_context "socket"
+    let(:subject) { described_class }
+
+    describe "instance_methods" do
+      describe "call" do
+        context "when no keyword is passed" do
+          it "sends the list of help commands to the user" do
+            spec_socket_server do
+              player = build(:player_connection).player
+              obj = subject.new(player)
+              expect(player).to receive(:send_data).with(obj.command_list)
+              obj.call([])
+            end
+          end
+        end
+
+        context "when a keyword is passed" do
+          context "when the keyword is 'help'" do
+            it "sends the help text for the Command" do
+              spec_socket_server do
+                player = build(:player_connection).player
+                obj = subject.new(player)
+                expect(player).to receive(:send_data).with(obj.help)
+                obj.call(["help"])
+              end
+            end
+          end
+
+          context "when the command for the keyword doesn't exit" do
+            it "informs the player that no help is available" do
+              spec_socket_server do
+                player = build(:player_connection).player
+                obj = subject.new(player)
+                expect(player).to receive(:send_data).with(
+                  "foo is not a valid command. No help topic available."
+                )
+                obj.call(["foo"])
+              end
+            end
+          end
+
+          context "when the user is not authorized to run the commands " \
+            "associated to the keyword" do
+            it "informs the player that no help is available" do
+              spec_socket_server do
+                player = build(:player_connection).player
+                obj = subject.new(player)
+                expect(player).to receive(:send_data).with(
+                  "goto is not a valid command. No help topic available."
+                )
+                # This is an admin command and will fail for a normal user
+                obj.call(["goto"])
+              end
+            end
+          end
+
+          context "when the command responds to the 'help' method" do
+            it "responds with the help text" do
+              spec_socket_server do
+                player = build(:player_connection).player
+                obj = subject.new(player)
+                expect(player).to receive(:send_data).with(
+                  Commands::North.new(player).help
+                )
+                obj.call(["north"])
+              end
+            end
+          end
+
+          context "when the command does not have a 'help' method" do
+            let!(:mock_cmd) do
+              class Mock < CommandBase; end
+            end
+
+            it "advises the player that the command doesn't have help entry" do
+              spec_socket_server do
+                player = build(:player_connection).player
+                obj = subject.new(player)
+                expect(player).to receive(:send_data).with(
+                  "mock does not currently have a help entry."
+                )
+                obj.call(["mock"])
+              end
+            end
+          end
+        end
+      end
+
+      describe "help" do
+        it "returns a help string" do
+          expect(subject.new(create(:player)).help).to be_a(String)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Basic functionality for Help topics. Extends based off a 'help' method on each of the individual commands. Determines what can be seen via the policy functionality.