### PR TITLE
Area/Room Caching

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sector.create!(
+  name: Array.new(rand(1..3), RandomWord.nouns.next).join("_"),
+  character_code: "z",
+  symbol: ".",
+  color: "red",
+  alternate_symbol: "@",
+  alternate_color: "blue"
+)
+
+Area.create!(name: RandomWord.nouns.next.capitalize, dimension: 15)

--- a/lib/commands/look.rb
+++ b/lib/commands/look.rb
@@ -10,12 +10,20 @@ module Commands
       @area = room.area
       @initiator.send_data(area.map.show(room, 11, 25))
       @initiator.send_data(location_data)
+      @initiator.send_data(room_data)
     end
 
     private
 
     def location_data
-      "(#{@area.name}) [#{@room.x_coord}, #{@room.y_coord}]"
+      "(#{@area.name}) [#{@room.x_coord}.#{@room.y_coord}]\n\n"
+    end
+
+    def room_data
+      @initiator.roommates.each do |player|
+        @initiator.send_data "#{player.name.red} stands here."
+      end
+      nil
     end
   end
 end

--- a/lib/commands/movement_base.rb
+++ b/lib/commands/movement_base.rb
@@ -24,7 +24,7 @@ module Commands
     def process_move(x: 0, y: 0, exit_dir: "East", enter_dir: "West")
       if destination = Movement.linear(@initiator, x: x, y: y)
         @initiator.roommates.each do |p|
-          p.send_data "\n#{@initiator.name} exits #{exit_dir}.\n"
+          p.send_data "\n#{@initiator.name.red} exits #{exit_dir}.\n"
         end
 
         @initiator.room = destination
@@ -32,7 +32,7 @@ module Commands
         Look.new(@initiator).call
 
         @initiator.roommates.each do |p|
-          p.send_data "\n#{@initiator.name} enters from the #{enter_dir}.\n"
+          p.send_data "\n#{@initiator.name.red} enters from the #{enter_dir}.\n"
         end
       else
         @initiator.send_data "You can't go that way!\n"

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -17,10 +17,10 @@ class Game
 
   def initialize
     @connections = ConnectionPool.new
+    @world ||= build_world
   end
 
   def run(ip: "127.0.0.1", port: "8081", socket_server: EventMachine, &block)
-    @world ||= build_world
     @server ||= socket_server.run do |s|
       # hit Control + C to stop
       Signal.trap("INT")  { socket_server.stop }
@@ -33,10 +33,15 @@ class Game
 
   def build_world
     World.new.tap do |world|
-      world[:areas] = {}
-      world[:rooms] = {}
-      Area.all.each { |area| world[:areas][area.id] = area }
-      Room.all.each { |room| world[:rooms][room.id] = room }
+      Area.all.each do |area|
+        world.areas[area.id] = {}
+        world.areas[area.id]["area"] = area
+        world.areas[area.id]["rooms"] = {}
+      end
+      Room.all.each do |room|
+        world.rooms[room.id] = room
+        world.areas[room.area_id]["rooms"][room.id] = room
+      end
     end
   end
 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -19,7 +19,8 @@ class Game
 
   def initialize
     @connections = ConnectionPool.new
-    build_world
+    @world = World.new
+    @world.build
   end
 
   def run(ip: "127.0.0.1", port: "8081", socket_server: EventMachine, &block)
@@ -30,22 +31,6 @@ class Game
 
       socket_server.start_server ip, port, PlayerConnection
       yield(socket_server) if block_given?
-    end
-  end
-
-  def build_world
-    @world = World.new.tap do |world|
-      Area.all.each do |area|
-        world.areas[area.id] = {}
-        world.areas[area.id]["area"] = area
-        world.areas[area.id]["rooms"] = {}
-      end
-      #binding.pry
-
-      Room.all.each do |room|
-        world.rooms[room.id] = room
-        world.areas[room.area_id]["rooms"][room.id] = room
-      end
     end
   end
 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -6,6 +6,8 @@ require 'forwardable'
 require_relative 'connection_pool'
 require_relative 'player_connection'
 require_relative 'world'
+require_relative "models/area"
+require_relative "models/room"
 
 class Game
   extend Forwardable
@@ -17,7 +19,7 @@ class Game
 
   def initialize
     @connections = ConnectionPool.new
-    @world ||= build_world
+    build_world
   end
 
   def run(ip: "127.0.0.1", port: "8081", socket_server: EventMachine, &block)
@@ -32,12 +34,14 @@ class Game
   end
 
   def build_world
-    World.new.tap do |world|
+    @world = World.new.tap do |world|
       Area.all.each do |area|
         world.areas[area.id] = {}
         world.areas[area.id]["area"] = area
         world.areas[area.id]["rooms"] = {}
       end
+      #binding.pry
+
       Room.all.each do |room|
         world.rooms[room.id] = room
         world.areas[room.area_id]["rooms"][room.id] = room

--- a/lib/map.rb
+++ b/lib/map.rb
@@ -13,7 +13,9 @@ class Map
           sector = room.sector
 
           map << if room == center_room
-            "*".colorize(:yellow).blink
+            "*".cyan.blink
+          elsif room.occupied?
+            "*".red
           else
             sector.symbol.colorize(sector.color)
           end

--- a/lib/models/area.rb
+++ b/lib/models/area.rb
@@ -10,6 +10,7 @@
 #
 
 require "active_record"
+require_relative "../game"
 
 class Area < ActiveRecord::Base
   has_many :rooms
@@ -18,9 +19,16 @@ class Area < ActiveRecord::Base
   }
 
   after_create :create_rooms
+  after_create :rebuild
 
+  def rebuild
+    Game.instance.build_world
+  end
   def rooms
-    Game.instance.world.areas[id]["rooms"].values || self[:rooms]
+    #binding.pry
+    rooms = Game.instance.world.areas.dig(id, "rooms")
+    rooms ? rooms.values : Room.where("area_id = ?", id)
+    #Room.where("area_id = ?", id) if game_rooms.empty?
   end
 
   def coord_index_range
@@ -51,7 +59,7 @@ class Area < ActiveRecord::Base
           override: true,
           y_coord: grid_coord_index + y_index,
           x_coord: grid_coord_index + x_index,
-          area: self,
+          area_id: id,
           sector: Sector.first
         )
       end

--- a/lib/models/area.rb
+++ b/lib/models/area.rb
@@ -12,8 +12,6 @@
 require "active_record"
 
 class Area < ActiveRecord::Base
-  attr_accessor :cached_rooms
-
   has_many :rooms
   validates :dimension, presence: true, numericality: {
     odd: true, greater_than_or_equal_to: 15, less_than_or_equal_to: 101
@@ -22,8 +20,7 @@ class Area < ActiveRecord::Base
   after_create :create_rooms
 
   def rooms
-    Game.instance.world[:rooms].values || super
-    #@cached_rooms ||= super
+    Game.instance.world.areas[id]["rooms"].values || self[:rooms]
   end
 
   def coord_index_range
@@ -50,7 +47,7 @@ class Area < ActiveRecord::Base
 
     dimension.times do |y_index|
       dimension.times do |x_index|
-        rooms << Room.create!(
+        Room.create!(
           override: true,
           y_coord: grid_coord_index + y_index,
           x_coord: grid_coord_index + x_index,

--- a/lib/models/area.rb
+++ b/lib/models/area.rb
@@ -19,16 +19,15 @@ class Area < ActiveRecord::Base
   }
 
   after_create :create_rooms
-  after_create :rebuild
+  after_create :rebuild_world
 
-  def rebuild
-    Game.instance.build_world
+  def rebuild_world
+    Game.instance.world.build
   end
+
   def rooms
-    #binding.pry
     rooms = Game.instance.world.areas.dig(id, "rooms")
     rooms ? rooms.values : Room.where("area_id = ?", id)
-    #Room.where("area_id = ?", id) if game_rooms.empty?
   end
 
   def coord_index_range

--- a/lib/models/area.rb
+++ b/lib/models/area.rb
@@ -12,6 +12,8 @@
 require "active_record"
 
 class Area < ActiveRecord::Base
+  attr_accessor :cached_rooms
+
   has_many :rooms
   validates :dimension, presence: true, numericality: {
     odd: true, greater_than_or_equal_to: 15, less_than_or_equal_to: 101
@@ -20,7 +22,8 @@ class Area < ActiveRecord::Base
   after_create :create_rooms
 
   def rooms
-    @rooms ||= super
+    Game.instance.world[:rooms].values || super
+    #@cached_rooms ||= super
   end
 
   def coord_index_range

--- a/lib/models/player.rb
+++ b/lib/models/player.rb
@@ -29,7 +29,7 @@ class Player < ActiveRecord::Base
   [:admin?, :is_admin?].each{ |m| alias_attribute m, :admin }
 
   def room
-    Game.instance.world[:rooms][room_id] || Room.find(room_id)
+    Game.instance.world.rooms[room_id] || Room.find(room_id)
   end
 
   # Through relationship is significantly slower & this takes cache into account

--- a/lib/models/player.rb
+++ b/lib/models/player.rb
@@ -24,11 +24,15 @@ class Player < ActiveRecord::Base
     in: VALID_RACES, message: "%{value} is not a valid race"
   }
 
-  belongs_to :room, required: true, autosave: true
+  belongs_to :room, required: true
 
   [:admin?, :is_admin?].each{ |m| alias_attribute m, :admin }
 
-  # Through relationship is significantly slower
+  def room
+    Game.instance.world[:rooms][room_id] || Room.find(room_id)
+  end
+
+  # Through relationship is significantly slower & this takes cache into account
   def area
     room.area
   end

--- a/lib/models/room.rb
+++ b/lib/models/room.rb
@@ -30,7 +30,7 @@ class Room < ActiveRecord::Base
   has_many :occupants, foreign_key: "room_id", class_name: "Player"
 
   def area
-    Game.instance.world[:areas][area_id] || Area.find(area_id)
+    Game.instance.world.areas[area_id]["area"] || Area.find(area_id)
   end
 
   def connected_occupants
@@ -42,7 +42,9 @@ class Room < ActiveRecord::Base
   end
 
   def unique_coordinates_by_area
-    rooms = area.rooms.where("x_coord = ? AND y_coord = ?", x_coord, y_coord)
+    rooms = area.rooms.select do |room|
+      room.x_coord == x_coord && room.y_coord == y_coord
+    end
 
     if rooms.any? && !rooms.include?(self)
       errors.add(:x_coord, "and Y coord already exist in Area (#{area.name})")

--- a/lib/models/room.rb
+++ b/lib/models/room.rb
@@ -37,6 +37,10 @@ class Room < ActiveRecord::Base
     end.compact
   end
 
+  def occupied?
+    connected_occupants.any?
+  end
+
   def unique_coordinates_by_area
     rooms = area.rooms.where("x_coord = ? AND y_coord = ?", x_coord, y_coord)
 

--- a/lib/models/room.rb
+++ b/lib/models/room.rb
@@ -30,7 +30,7 @@ class Room < ActiveRecord::Base
   has_many :occupants, foreign_key: "room_id", class_name: "Player"
 
   def area
-    Game.instance.world.areas[area_id]["area"] || Area.find(area_id)
+    Game.instance.world.areas.dig(area_id, "area") || Area.find(area_id)
   end
 
   def connected_occupants

--- a/lib/models/room.rb
+++ b/lib/models/room.rb
@@ -29,12 +29,12 @@ class Room < ActiveRecord::Base
 
   has_many :occupants, foreign_key: "room_id", class_name: "Player"
 
-  def connected_occupants
-    connections = Game.instance.players
+  def area
+    Game.instance.world[:areas][area_id] || Area.find(area_id)
+  end
 
-    occupants.flat_map do |player|
-      connections.detect{|c| c.id == player.id}
-    end.compact
+  def connected_occupants
+    Game.instance.players.select{|p| p.room_id == id}
   end
 
   def occupied?

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class World < Hash
+  def areas
+    self[:areas] ||= {}
+  end
+
+  def rooms
+    self[:rooms] ||= {}
+  end
 end

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -1,11 +1,30 @@
 # frozen_string_literal: true
 
 class World < Hash
-  def areas
-    self[:areas] ||= {}
+  attr_accessor :areas
+
+  def initialize
+    @areas = {}
+    build
   end
 
   def rooms
-    self[:rooms] ||= {}
+    areas.each_with_object({}) do |(area_key, area_value), room_hash|
+      area_value.dig("rooms").each do |room_key, room_value|
+        room_hash[room_key] = room_value
+      end
+    end
+  end
+
+  def build
+    Area.all.each do |area|
+      @areas[area.id] = {}
+      @areas[area.id]["area"] = area
+      @areas[area.id]["rooms"] = {}
+    end
+
+    Room.all.each do |room|
+      @areas[room.area_id]["rooms"][room.id] = room
+    end
   end
 end

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class World < Hash
+end

--- a/spec/lib/command_parser_spec.rb
+++ b/spec/lib/command_parser_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CommandParser, type: [:parser] do
   describe "instance_methods" do
     describe "call" do
       it "instantiates the command class when one exists" do
-        spec_socket_server(debug: true) do
+        spec_socket_server do
           connection = build(:player_connection)
           obj = subject.new(connection.player)
           expect(Commands::Mock).to receive(:new).and_call_original

--- a/spec/lib/commands/northeast_spec.rb
+++ b/spec/lib/commands/northeast_spec.rb
@@ -35,12 +35,9 @@ module Commands
           spec_socket_server do
             movement_setup
 
-            @player.room = Game.instance.world.areas[@area.id]["rooms"].values.detect do |r|
-              r.x_coord == @coord_range.max && r.y_coord == @coord_range.min
-            end
-            #@player.room = Room.where(
-              #"x_coord = ? AND y_coord = ?", @coord_range.max, @coord_range.min,
-            #).first
+            @player.room = Room.where(
+              "x_coord = ? AND y_coord = ?", @coord_range.max, @coord_range.min,
+            ).first
 
             expect(@player.room.x_coord).to be(@coord_range.max)
             expect(@player.room.y_coord).to be(@coord_range.min)

--- a/spec/lib/commands/northeast_spec.rb
+++ b/spec/lib/commands/northeast_spec.rb
@@ -35,9 +35,12 @@ module Commands
           spec_socket_server do
             movement_setup
 
-            @player.room = Room.where(
-              "x_coord = ? AND y_coord = ?", @coord_range.max, @coord_range.min,
-            ).first
+            @player.room = Game.instance.world.areas[@area.id]["rooms"].values.detect do |r|
+              r.x_coord == @coord_range.max && r.y_coord == @coord_range.min
+            end
+            #@player.room = Room.where(
+              #"x_coord = ? AND y_coord = ?", @coord_range.max, @coord_range.min,
+            #).first
 
             expect(@player.room.x_coord).to be(@coord_range.max)
             expect(@player.room.y_coord).to be(@coord_range.min)

--- a/spec/lib/commands/southwest_spec.rb
+++ b/spec/lib/commands/southwest_spec.rb
@@ -32,7 +32,7 @@ module Commands
         end
 
         it "moves spherically" do
-          spec_socket_server(debug: true) do
+          spec_socket_server do
             movement_setup
 
             @player.room = Room.where(

--- a/spec/lib/commands/southwest_spec.rb
+++ b/spec/lib/commands/southwest_spec.rb
@@ -32,7 +32,7 @@ module Commands
         end
 
         it "moves spherically" do
-          spec_socket_server do
+          spec_socket_server(debug: true) do
             movement_setup
 
             @player.room = Room.where(

--- a/spec/lib/commands/southwest_spec.rb
+++ b/spec/lib/commands/southwest_spec.rb
@@ -36,7 +36,7 @@ module Commands
             movement_setup
 
             @player.room = Room.where(
-              "x_coord = ? AND y_coord = ?", @coord_range.min, @coord_range.max,
+              "x_coord = ? AND y_coord = ?", @coord_range.min, @coord_range.max
             ).first
 
             expect(@player.room.x_coord).to be(@coord_range.min)

--- a/spec/lib/movement_spec.rb
+++ b/spec/lib/movement_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe Movement, type: [:service] do
           send_player_to_area_center(player)
 
           expect(subject.linear(player, x: 1, y: 1)).to eq(
-            player.area.rooms.where(
-              "x_coord = ? AND y_coord = ?",
-              player.room.x_coord + 1,
-              player.room.y_coord + 1
-            ).first
+            player.area.rooms.detect do |room|
+              room.x_coord == (player.room.x_coord + 1) &&
+                room.y_coord == (player.room.y_coord + 1)
+            end
           )
         end
       end

--- a/spec/lib/movement_spec.rb
+++ b/spec/lib/movement_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Movement, type: [:service] do
   describe "class_methods" do
     describe "linear" do
       it "returns the room object" do
-        spec_socket_server(debug: true) do
+        spec_socket_server do
           player = create(:player)
           send_player_to_area_center(player)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,11 @@ RSpec.configure do |config|
     mocks.allow_message_expectations_on_nil = false
   end
 
+  # DB Seeds
+  config.before :suite do
+    require_relative "../db/seeds/test"
+  end
+
   config.after :suite do
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/support/shared_context/socket.rb
+++ b/spec/support/shared_context/socket.rb
@@ -52,10 +52,10 @@ RSpec.shared_context "socket", shared_context: :meta_data do
     send_player_to_area_center(player2)
 
     expect(player2).to receive(:send_data).with(
-      "\n#{@player.name} exits #{exit_dir}.\n"
+      "\n#{@player.name.red} exits #{exit_dir}.\n"
     )
     expect(player3).to receive(:send_data).with(
-      "\n#{@player.name} enters from the #{enter_dir}.\n"
+      "\n#{@player.name.red} enters from the #{enter_dir}.\n"
     )
     subject.new(@player).call
   end


### PR DESCRIPTION
This addresses map delays and inaccuracies due to passive database loading. Entities on the map won't appear in the correct place until the unit (player) querying the database initiates it. This caches the map on initial load so everyone is querying the same area/room objects.